### PR TITLE
Add LoongArch support on Linux platform

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Fangming Fang <Fangming.Fang@arm.com>
 Vadim Skipin <vadim.skipin@gmail.com>
 Rodrigo Tobar <rtobar@icrar.org>
 Harry Mallon <hjmallon@gmail.com>
+Min Zhou <zhoumin@loongson.cn>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,17 @@ int main() {
 " HAVE_ARM64_CRC32C)
 set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
 
+# Check for LoongArch hardware crc32c instruction support in the compiler.
+check_cxx_source_compiles("
+#include <larchintrin.h>
+
+int main() {
+  int crc = 0;
+  crc = __crcc_w_b_w('c', crc);
+  return 0;
+}
+" HAVE_LOONGARCH_CRC32C)
+
 # Check for strong getauxval() support in the system headers.
 check_cxx_source_compiles("
 #include <arm_acle.h>
@@ -240,6 +251,20 @@ if(BUILD_SHARED_LIBS)
   set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif(BUILD_SHARED_LIBS)
 
+# LOONGARCH CRC32C code is built separately.
+add_library(crc32c_loongarch OBJECT "")
+target_sources(crc32c_loongarch
+  PRIVATE
+    "${PROJECT_BINARY_DIR}/include/crc32c/crc32c_config.h"
+    "src/crc32c_loongarch.cc"
+    "src/crc32c_loongarch.h"
+)
+
+# CMake only enables PIC by default in SHARED and MODULE targets.
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET crc32c_loongarch PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+endif(BUILD_SHARED_LIBS)
+
 # SSE4.2 code is built separately, so we don't accidentally compile unsupported
 # instructions into code that gets run without SSE4.2 support.
 add_library(crc32c_sse42 OBJECT "")
@@ -269,6 +294,7 @@ add_library(crc32c ""
   # TODO(pwnall): Move the TARGET_OBJECTS generator expressions to the PRIVATE
   # section of target_sources when cmake_minimum_required becomes 3.9 or above.
   $<TARGET_OBJECTS:crc32c_arm64>
+  $<TARGET_OBJECTS:crc32c_loongarch>
   $<TARGET_OBJECTS:crc32c_sse42>
 )
 target_sources(crc32c
@@ -277,6 +303,8 @@ target_sources(crc32c
     "src/crc32c_arm64.h"
     "src/crc32c_arm64_check.h"
     "src/crc32c_internal.h"
+    "src/crc32c_loongarch.h"
+    "src/crc32c_loongarch_check.h"
     "src/crc32c_portable.cc"
     "src/crc32c_prefetch.h"
     "src/crc32c_read_le.h"
@@ -331,6 +359,7 @@ if(CRC32C_BUILD_TESTS)
       "${PROJECT_BINARY_DIR}/include/crc32c/crc32c_config.h"
       "src/crc32c_arm64_unittest.cc"
       "src/crc32c_extend_unittests.h"
+      "src/crc32c_loongarch_unittest.cc"
       "src/crc32c_portable_unittest.cc"
       "src/crc32c_prefetch_unittest.cc"
       "src/crc32c_read_le_unittest.cc"

--- a/src/crc32c.cc
+++ b/src/crc32c.cc
@@ -10,6 +10,8 @@
 #include "./crc32c_arm64.h"
 #include "./crc32c_arm64_check.h"
 #include "./crc32c_internal.h"
+#include "./crc32c_loongarch.h"
+#include "./crc32c_loongarch_check.h"
 #include "./crc32c_sse42.h"
 #include "./crc32c_sse42_check.h"
 
@@ -22,6 +24,9 @@ uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count) {
 #elif HAVE_ARM64_CRC32C
   static bool can_use_arm64_crc32 = CanUseArm64Crc32();
   if (can_use_arm64_crc32) return ExtendArm64(crc, data, count);
+#elif HAVE_LOONGARCH_CRC32C
+  static bool can_use_loongarch_crc32 = CanUseLoongArchCrc32();
+  if (can_use_loongarch_crc32) return ExtendLoongArch(crc, data, count);
 #endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
   return ExtendPortable(crc, data, count);

--- a/src/crc32c_config.h.in
+++ b/src/crc32c_config.h.in
@@ -22,6 +22,10 @@
 // the vmull_p64 intrinsics.
 #cmakedefine01 HAVE_ARM64_CRC32C
 
+// Define to 1 if targeting LoongArch and the compiler has the
+// __crcc_w_{b,h,w,d}_w intrinsics.
+#cmakedefine01 HAVE_LOONGARCH_CRC32C
+
 // Define to 1 if the system libraries have the getauxval function in the
 // <sys/auxv.h> header. Should be true on Linux and Android API level 20+.
 #cmakedefine01 HAVE_STRONG_GETAUXVAL

--- a/src/crc32c_loongarch.cc
+++ b/src/crc32c_loongarch.cc
@@ -1,0 +1,48 @@
+// Copyright 2022 The CRC32C Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "./crc32c_internal.h"
+#include "./crc32c_loongarch.h"
+
+#if HAVE_LOONGARCH_CRC32C
+
+#include <larchintrin.h>
+
+namespace crc32c {
+
+uint32_t ExtendLoongArch(uint32_t crc, const uint8_t *data, size_t size) {
+
+  crc = crc ^ kCRC32Xor;
+
+  while (size >= sizeof(uint64_t)) {
+    crc = __crcc_w_d_w(*(const uint64_t *)data, crc);
+    data += sizeof(uint64_t);
+    size -= sizeof(uint64_t);
+  }
+
+  if (size & sizeof(uint32_t)) {
+    crc = __crcc_w_w_w(*(const uint32_t *)data, crc);
+    data += sizeof(uint32_t);
+    size -= sizeof(uint32_t);
+  }
+
+  if (size & sizeof(uint16_t)) {
+    crc = __crcc_w_h_w(*(const uint16_t *)data, crc);
+    data += sizeof(uint16_t);
+    size -= sizeof(uint16_t);
+  }
+
+  if (size & sizeof(uint8_t)) {
+    crc = __crcc_w_b_w(*data, crc);
+  }
+
+  return crc ^ kCRC32Xor;
+}
+
+}  // namespace crc32c
+
+#endif  // HAVE_LOONGARCH_CRC32C

--- a/src/crc32c_loongarch.h
+++ b/src/crc32c_loongarch.h
@@ -1,0 +1,25 @@
+// Copyright 2022 The CRC32C Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// LoongArch-specific code
+
+#ifndef CRC32C_CRC32C_LOONGARCH_H_
+#define CRC32C_CRC32C_LOONGARCH_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "crc32c/crc32c_config.h"
+
+#if HAVE_LOONGARCH_CRC32C
+
+namespace crc32c {
+
+uint32_t ExtendLoongArch(uint32_t crc, const uint8_t* data, size_t count);
+
+}  // namespace crc32c
+
+#endif  // HAVE_LOONGARCH_CRC32C
+
+#endif  // CRC32C_CRC32C_LOONGARCH_H_

--- a/src/crc32c_loongarch_check.h
+++ b/src/crc32c_loongarch_check.h
@@ -1,0 +1,40 @@
+// Copyright 2022 The CRC32C Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// LoongArch-specific code checking for the availability of CRC32C instructions.
+
+#ifndef CRC32C_CRC32C_LOONGARCH_CHECK_H_
+#define CRC32C_CRC32C_LOONGARCH_CHECK_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "crc32c/crc32c_config.h"
+
+#ifdef __linux__
+#include <sys/auxv.h>
+#endif
+
+#if HAVE_LOONGARCH_CRC32C
+
+#define AT_HWCAP 16
+
+namespace crc32c {
+
+inline bool CanUseLoongArchCrc32() {
+#if defined (__linux__)
+  // From 'arch/loongarch/include/uapi/asm/hwcap.h' in Linux kernel source code.
+  constexpr unsigned long HWCAP_LOONGARCH_CRC32 = 1 << 6;
+  unsigned long hwcap = getauxval(AT_HWCAP);
+
+  return hwcap & HWCAP_LOONGARCH_CRC32;
+#endif
+  return false;
+}
+
+}  // namespace crc32c
+
+#endif  // HAVE_LOONGARCH_CRC32C
+
+#endif  // CRC32C_CRC32C_LOONGARCH_CHECK_H_

--- a/src/crc32c_loongarch_unittest.cc
+++ b/src/crc32c_loongarch_unittest.cc
@@ -1,0 +1,24 @@
+// Copyright 2022 The CRC32C Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "gtest/gtest.h"
+
+#include "./crc32c_loongarch.h"
+#include "./crc32c_extend_unittests.h"
+
+namespace crc32c {
+
+#if HAVE_LOONGARCH_CRC32C
+
+struct LoongArchTestTraits {
+  static uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count) {
+    return ExtendLoongArch(crc, data, count);
+  }
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(LoongArch, ExtendTest, LoongArchTestTraits);
+
+#endif  // HAVE_LOONGARCH_CRC32C
+
+}  // namespace crc32c


### PR DESCRIPTION
Signed-off-by: Min Zhou <zhoumin@loongson.cn>

This patch has been tested by the following steps suggested in README.md for development:
$ mkdir build
$ cd build
$ cmake .. && cmake --build . && ctest --output-on-failure
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works

[...]

[ 98%] Building CXX object third_party/benchmark/src/CMakeFiles/benchmark_main.dir/benchmark_main.cc.o
[100%] Linking CXX shared library libbenchmark_main.so
[100%] Built target benchmark_main
Test project /home/zhoumin/crc32c/build
    Start 1: crc32c_tests
1/2 Test #1: crc32c_tests .....................   Passed   38.90 sec
    Start 2: crc32c_capi_tests
2/2 Test #2: crc32c_capi_tests ................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  38.90 sec

@bibo-mao